### PR TITLE
Update main.yml

### DIFF
--- a/roles/pwn-windows/tasks/main.yml
+++ b/roles/pwn-windows/tasks/main.yml
@@ -49,5 +49,5 @@
     owner: "{{ user_dir }}"
   loop:
     - https://download.sysinternals.com/files/SysinternalsSuite.zip
-    - https://github.com/gentilkiwi/mimikatz/releases/download/2.2.0-20200918-fix/mimikatz_trunk.zip
+    - https://github.com/gentilkiwi/mimikatz/releases/download/2.2.0-20210810-2/mimikatz_trunk.zip
   become: yes


### PR DESCRIPTION
updated pwn-win tasks for downloading mimikatz. The link was broken being pointed to the old release.